### PR TITLE
Now can view results

### DIFF
--- a/jwaldor.survey2/database-boilerplate-main/prisma/migrations/20240807181719_initial/migration.sql
+++ b/jwaldor.survey2/database-boilerplate-main/prisma/migrations/20240807181719_initial/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "Survey" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+
+    CONSTRAINT "Survey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Question" (
+    "id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "ordering" INTEGER NOT NULL,
+    "blockId" TEXT NOT NULL,
+
+    CONSTRAINT "Question_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SurveyResponse" (
+    "id" TEXT NOT NULL,
+
+    CONSTRAINT "SurveyResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Responses" (
+    "id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "response_instance" TEXT NOT NULL,
+    "question_id" TEXT,
+
+    CONSTRAINT "Responses_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Block" (
+    "id" TEXT NOT NULL,
+    "ordering" INTEGER NOT NULL,
+    "surveyId" TEXT NOT NULL,
+
+    CONSTRAINT "Block_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Question" ADD CONSTRAINT "Question_blockId_fkey" FOREIGN KEY ("blockId") REFERENCES "Block"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Responses" ADD CONSTRAINT "Responses_response_instance_fkey" FOREIGN KEY ("response_instance") REFERENCES "SurveyResponse"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Responses" ADD CONSTRAINT "Responses_question_id_fkey" FOREIGN KEY ("question_id") REFERENCES "Question"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Block" ADD CONSTRAINT "Block_surveyId_fkey" FOREIGN KEY ("surveyId") REFERENCES "Survey"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/jwaldor.survey2/src/main.tsx
+++ b/jwaldor.survey2/src/main.tsx
@@ -5,8 +5,8 @@ import { createBrowserRouter, Outlet, RouterProvider } from "react-router-dom";
 import "./index.css";
 import Root from "./routes/root";
 import CreateSurvey from "./routes/createsurvey";
-import SurveySuccess from "./routes/surveysuccess";
 import CompleteSurvey from "./routes/completesurvey";
+import ViewResults from "./routes/viewresults";
 
 const router = createBrowserRouter([
   {
@@ -16,7 +16,7 @@ const router = createBrowserRouter([
       { index: true, element: <Root /> },
       { path: "/create-survey", element: <CreateSurvey /> },
       { path: "/complete-survey/:id", element: <CompleteSurvey /> },
-      { path: "/success", element: <SurveySuccess /> },
+      { path: "/view-results/:id", element: <ViewResults /> },
     ],
   },
 ]);

--- a/jwaldor.survey2/src/routes/completesurvey.tsx
+++ b/jwaldor.survey2/src/routes/completesurvey.tsx
@@ -1,0 +1,112 @@
+//clzjxhj7u003w1xwcao4jjg83
+
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import axios from "axios";
+// import _ from "lodash";
+
+function CompleteSurvey() {
+  console.log(useParams());
+  const { id } = useParams();
+  let [success, setSuccess] = useState(false);
+  const [blocks, setBlocks] = useState([]);
+
+  useEffect(() => {
+    axios
+      .get(`http://localhost:3000/survey-questions/${id}`)
+      .then((response) => {
+        console.log(response.data.all_questions);
+        console.log("blocks", response.data.all_questions.Blocks[0].id);
+        setBlocks(response.data.all_questions.Blocks);
+        console.log(blocks, "questions");
+        blocks.map((block) => {
+          console.log("block", block);
+        });
+        // response.data.blocks.groupBy(({ block_order}) => block_order)
+        // surveyFields = Object.groupBy(
+        //   response.data.blocks,
+
+        // );
+      })
+      .catch((error) => console.log(error));
+  }, []);
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    console.log("response", formData.get("response"));
+    const k = formData.keys();
+    // for (const value of formData.values()) {
+    //   console.log(value);
+    // }
+    const answer_obj = { question_ids: [], text: [] };
+    for (const key of formData.keys()) {
+      console.log("key", key);
+      console.log(formData.get(key));
+      answer_obj.question_ids.push(key);
+      answer_obj.text.push(formData.get(key));
+      console.log(formData.get(key));
+    }
+    console.log("answer_obj", answer_obj);
+    // console.log(k.next());
+    // console.log(k.next());
+    // console.log(k.next());
+    axios
+      .post("http://localhost:3000/answer-survey-questions", answer_obj)
+      .then((response) => {
+        console.log("sent request");
+        console.log(response.data);
+      })
+      .catch((error) => console.log(error));
+    setSuccess(true);
+  };
+  console.log("surveyId", id);
+  //   const [responses, setResponses] = useState<Array<Block>>([]);
+  return (
+    <>
+      {success ? (
+        <div>Success!</div>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          {blocks.map((block) => (
+            <div key={block.id}>
+              <br></br>
+              {block.Question.map((q) => (
+                <div key={q.id}>
+                  {q.text}
+
+                  <input name={q.id} type="text"></input>
+                </div>
+              ))}
+            </div>
+          ))}
+          <button type="submit">Submit</button>
+        </form>
+      )}
+    </>
+  );
+}
+
+export default CompleteSurvey;
+
+// block_order: block.ordering,
+// ordering: question.ordering,
+// question_text: question.text,
+// question_id: question.id,
+
+{
+  /* <form
+onSubmit={(event) =>
+  
+}
+>
+<input
+  name="question"
+  type="text"
+  // value={currtitle}
+  // onChange={(e) => setTitle(e.target.value)}
+></input>
+<button data-block={block.blockId} type="submit">
+  Add question
+</button>
+</form> */
+}

--- a/jwaldor.survey2/src/routes/surveysuccess.tsx
+++ b/jwaldor.survey2/src/routes/surveysuccess.tsx
@@ -1,0 +1,9 @@
+function SurveySuccess() {
+  return (
+    <>
+      <div>Success!</div>
+    </>
+  );
+}
+
+export default SurveySuccess;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 174ddb786805295e7e178a2840bcfba71423c25d  | 
|--------|--------|

### Summary:
This PR adds functionality to view survey results, updates database schema, and modifies client-side routing and components for survey completion and success display.

**Key points**:
- Added `survey-results/:survey_id` endpoint in `jwaldor.survey2/database-boilerplate-main/server.ts` to fetch survey results.
- Created `jwaldor.survey2/database-boilerplate-main/prisma/migrations/20240807181719_initial/migration.sql` to define database schema for `Survey`, `Question`, `SurveyResponse`, `Responses`, and `Block` tables with necessary foreign keys.
- Updated `jwaldor.survey2/src/main.tsx` to include `ViewResults` route.
- Implemented `CompleteSurvey` component in `jwaldor.survey2/src/routes/completesurvey.tsx` to handle survey completion and submission.
- Added `SurveySuccess` component in `jwaldor.survey2/src/routes/surveysuccess.tsx` to display success message after survey completion.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->